### PR TITLE
Add external provider

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -7,5 +7,8 @@ terraform {
     aws = {
       source = "hashicorp/aws"
     }
+    external = {
+      source = "hashicorp/external"
+    }
   }
 }


### PR DESCRIPTION
Adds the `external` provider to versions.tf for Terraform 0.13.