### PR TITLE
SSO implementation for SCIM remediation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,12 @@ module "sso" {
   auth0_github_client_id     = ""
   auth0_github_client_secret = ""
   auth0_github_allowed_orgs  = ["ministryofjustice"]
-  auth0_allowed_domains      = ["@digital.justice.gov.uk"]
+  auth0_allowed_domains      = "@digital.justice.gov.uk"
   auth0_aws_sso_acs_url      = "https://region.signin.aws.amazon.com/platform/saml/acs/${random-key}"
   auth0_aws_sso_issuer_url   = "https://region.signin.aws.amazon.com/platform/saml/${random-key}"
+  sso_aws_region             = "eu-west-2"
+  sso_scim_token             = "${random-string}"
+  sso_tenant_id              = "${random-string}"
 }
 ```
 
@@ -29,6 +32,9 @@ module "sso" {
 | auth0_github_client_id     | GitHub OAuth app client ID for an Auth0 social connection            | string  | n/a     | yes      |
 | auth0_github_client_secret | GitHub OAuth app client secret for an Auth0 social connection        | string  | n/a     | yes      |
 | auth0_github_allowed_orgs  | A list of organisations a user has to be part of to authenticate     | list    | n/a     | yes      |
-| auth0_allowed_domains      | A list of authorised domains a user can have in their GitHub account | list    | n/a     | yes      |
+| auth0_allowed_domains      | An authorised domain a user must have in their GitHub account        | string  | n/a     | yes      |
 | auth0_aws_sso_acs_url      | AWS SSO ACS URL, as provided by AWS when you set up AWS SSO          | string  | n/a     | yes      |
 | auth0_aws_sso_issuer_url   | AWS SSO Issuer URL, as provided by AWS when you set up AWS SSO       | string  | n/a     | yes      |
+| sso_aws_region             | Region that AWS SSO is configured in (required for the SCIM URL)     | string  | n/a     | yes      |
+| sso_scim_token             | AWS SSO SCIM token                                                   | string  | n/a     | yes      |
+| sso_tenant_id              | AWS SSO tenant ID                                                    | string  | n/a     | yes      |

--- a/auth0-rules/allow-email-addresses.js
+++ b/auth0-rules/allow-email-addresses.js
@@ -6,10 +6,9 @@
   Otherwise, it will reject the user.
 */
 async function (user, context, callback) {
-  const allowedDomains = JSON.parse(configuration.ALLOWED_DOMAINS)
+  const allowedDomain = JSON.parse(configuration.ALLOWED_DOMAINS)
 
   if (context.connectionStrategy === 'github') {
-
     const identity = user.identities.find(identity => identity.provider === 'github')
 
     if (identity) {
@@ -20,17 +19,12 @@ async function (user, context, callback) {
       const userEmails = await octokit.request('GET /user/emails').catch(error => callback(new Error(`Error retrieving email addresses from GitHub: ${error}`)))
 
       // Check if any of the user's email addresses end with an authorized domain
-      const authorisedEmails = userEmails.data.map(email => email.email).filter(email => {
-        for (const domain of allowedDomains) {
-          return email.endsWith(domain)
-        }
-      })
+      const authorisedEmails = userEmails.data.map(email => email.email).filter(email => email.endsWith(allowedDomain))
 
       if (authorisedEmails.length) {
-        return callback(null, {...user, emails: authorisedEmails}, context)
+        return callback(null, { ...user, emails: authorisedEmails }, context)
       }
     }
-
   }
 
   return callback(new UnauthorizedError('Access denied.'))

--- a/auth0-rules/saml-mappings.js
+++ b/auth0-rules/saml-mappings.js
@@ -2,12 +2,14 @@
   This rule maps an authenticated user's information to the correct SAML attributes.
 */
 function (user, context, callback) {
+  const allowedDomain = JSON.parse(configuration.ALLOWED_DOMAINS)
+
   // AWS requires the SAML nameID format to be an email address, which must
   // exactly match an existing user in AWS SSO:
   // https://docs.aws.amazon.com/singlesignon/latest/userguide/troubleshooting.html
   const anyAuthorisedEmail = user.emails.find(item => item)
-  user.email = anyAuthorisedEmail
-  user.name = anyAuthorisedEmail
+  user.email = user.nickname + allowedDomain
+  user.name = user.nickname + allowedDomain
 
   return callback(null, user, context)
 }

--- a/auth0-rules/update-jit-user.js
+++ b/auth0-rules/update-jit-user.js
@@ -1,0 +1,48 @@
+/*
+  This role updates an AWS SSO user to their correct groups.
+*/
+async function (user, context, callback) {
+  const allowedDomain = JSON.parse(configuration.ALLOWED_DOMAINS)
+  const awsSsoUrl = `https://scim.${JSON.parse(configuration.SSO_REGION)}.amazonaws.com/${JSON.parse(configuration.SSO_TENANT_ID)}/scim/v2`
+  const axios = require('axios@0.19.2')
+  axios.defaults.headers.common.Authorization = `Bearer ${JSON.parse(configuration.SSO_SCIM_TOKEN)}`
+
+  /*
+    Get SSO user ID by username
+  */
+  const url = `${awsSsoUrl}/Users?filter=userName eq "${user.nickname}${allowedDomain}"`
+  const ssoUser = await axios.get(url).then(response => response.data).catch(error => {
+    console.log('[error]', error)
+  })
+
+  if (ssoUser.totalResults === 1) {
+    await Promise.all(
+      user.teams.map(async team => {
+        const url = `${awsSsoUrl}/Groups?filter=displayName eq "${team}"`
+        const ssoGroupId = await axios.get(url).then(response => response.data.Resources[0].id).catch(error => {
+          console.log('[error]', error)
+        })
+
+        const patchUrl = `${awsSsoUrl}/Groups/${ssoGroupId}`
+        await axios.patch(patchUrl, {
+          schemas: [
+            'urn:ietf:params:scim:api:messages:2.0:PatchOp'
+          ],
+          Operations: [{
+            op: 'add',
+            path: 'members',
+            value: [{
+              value: ssoUser.Resources[0].id
+            }]
+          }]
+        }).catch(error => {
+          console.log('[error]', error)
+        })
+      })
+    )
+
+    return callback(null, user, context)
+  } else {
+    return callback(new UnauthorizedError('Access denied: user does not exist in AWS SSO:', user))
+  }
+}

--- a/auth0.tf
+++ b/auth0.tf
@@ -70,6 +70,21 @@ resource "auth0_rule_config" "github_allowed_domains" {
   value = jsonencode(var.auth0_allowed_domains)
 }
 
+resource "auth0_rule_config" "sso_aws_region" {
+  key   = "SSO_REGION"
+  value = jsonencode(var.sso_aws_region)
+}
+
+resource "auth0_rule_config" "sso_scim_token" {
+  key   = "SSO_SCIM_TOKEN"
+  value = jsonencode(var.sso_scim_token)
+}
+
+resource "auth0_rule_config" "sso_tenant_id" {
+  key   = "SSO_TENANT_ID"
+  value = jsonencode(var.sso_tenant_id)
+}
+
 # Auth0 Rules: Attach rules from this repository
 resource "auth0_rule" "allow_github_organisations" {
   name    = "Allow specific GitHub Organisations"
@@ -90,4 +105,11 @@ resource "auth0_rule" "saml_mappings" {
   script  = file("${path.module}/auth0-rules/saml-mappings.js")
   enabled = true
   order   = 30
+}
+
+resource "auth0_rule" "update_jit_user" {
+  name    = "Update AWS SSO SCIM user with the correct groupings"
+  script  = file("${path.module}/auth0-rules/update-jit-user.js")
+  enabled = true
+  order   = 40
 }

--- a/variables.tf
+++ b/variables.tf
@@ -36,7 +36,7 @@ variable "auth0_github_allowed_orgs" {
 
 variable "auth0_allowed_domains" {
   description = "A list of authorised domains a user must have as part of their GitHub email addresses"
-  type        = list(string)
+  type        = string
 }
 
 variable "auth0_aws_sso_acs_url" {
@@ -47,4 +47,18 @@ variable "auth0_aws_sso_acs_url" {
 variable "auth0_aws_sso_issuer_url" {
   description = "AWS SSO: Issuer URL"
   type        = string
+}
+
+variable "sso_aws_region" {
+  type        = string
+  description = "Region that AWS SSO is configured in (required for the SCIM URL)"
+}
+variable "sso_scim_token" {
+  type        = string
+  description = "AWS SSO SCIM token. Generated and shown only once when you turn on AWS SSO automatic SCIM provisioning"
+}
+
+variable "sso_tenant_id" {
+  type        = string
+  description = "AWS SSO tenant ID. Available from the Automatic provisioning section in AWS SSO"
 }


### PR DESCRIPTION
This PR implements SCIM syncing for users and groups upon login within Auth0, after they have already been synced separately into the AWS SSO SCIM implementation. This allows us to keep track of changing team memberships within GitHub by doing it "just in time" rather than once a night.