### PR TITLE
Turn off email address checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,18 +23,19 @@ module "sso" {
 ```
 
 ## Inputs
-| Name                       | Description                                                          | Type    | Default | Required |
-|----------------------------|----------------------------------------------------------------------|---------|---------|----------|
-| auth0_tenant_domain        | Tenant domain from the Auth0 account to create applicable resources  | string  | n/a     | yes      |
-| auth0_client_id            | Auth0 application (Machine to Machine) client ID to utilise          | string  | n/a     | yes      |
-| auth0_client_secret        | Auth0 application (Machine to Machine) client secret to utilise      | string  | n/a     | yes      |
-| auth0_debug                | Whether to turn Auth0 debugging on or off                            | boolean | `false` | no       |
-| auth0_github_client_id     | GitHub OAuth app client ID for an Auth0 social connection            | string  | n/a     | yes      |
-| auth0_github_client_secret | GitHub OAuth app client secret for an Auth0 social connection        | string  | n/a     | yes      |
-| auth0_github_allowed_orgs  | A list of organisations a user has to be part of to authenticate     | list    | n/a     | yes      |
-| auth0_allowed_domains      | An authorised domain a user must have in their GitHub account        | string  | n/a     | yes      |
-| auth0_aws_sso_acs_url      | AWS SSO ACS URL, as provided by AWS when you set up AWS SSO          | string  | n/a     | yes      |
-| auth0_aws_sso_issuer_url   | AWS SSO Issuer URL, as provided by AWS when you set up AWS SSO       | string  | n/a     | yes      |
-| sso_aws_region             | Region that AWS SSO is configured in (required for the SCIM URL)     | string  | n/a     | yes      |
-| sso_scim_token             | AWS SSO SCIM token                                                   | string  | n/a     | yes      |
-| sso_tenant_id              | AWS SSO tenant ID                                                    | string  | n/a     | yes      |
+| Name                                  | Description                                                          | Type    | Default | Required |
+|---------------------------------------|----------------------------------------------------------------------|---------|---------|----------|
+| auth0_tenant_domain                   | Tenant domain from the Auth0 account to create applicable resources  | string  | n/a     | yes      |
+| auth0_client_id                       | Auth0 application (Machine to Machine) client ID to utilise          | string  | n/a     | yes      |
+| auth0_client_secret                   | Auth0 application (Machine to Machine) client secret to utilise      | string  | n/a     | yes      |
+| auth0_debug                           | Whether to turn Auth0 debugging on or off                            | boolean | `false` | no       |
+| auth0_github_client_id                | GitHub OAuth app client ID for an Auth0 social connection            | string  | n/a     | yes      |
+| auth0_github_client_secret            | GitHub OAuth app client secret for an Auth0 social connection        | string  | n/a     | yes      |
+| auth0_github_allowed_orgs             | A list of organisations a user has to be part of to authenticate     | list    | n/a     | yes      |
+| auth0_allowed_domains                 | An authorised domain a user must have in their GitHub account        | string  | n/a     | yes      |
+| auth0_aws_sso_acs_url                 | AWS SSO ACS URL, as provided by AWS when you set up AWS SSO          | string  | n/a     | yes      |
+| auth0_aws_sso_issuer_url              | AWS SSO Issuer URL, as provided by AWS when you set up AWS SSO       | string  | n/a     | yes      |
+| auth0_rule_enable_email_address_check | Whether to check someone has a verified email or not                 | boolean | `false` | no       |
+| sso_aws_region                        | Region that AWS SSO is configured in (required for the SCIM URL)     | string  | n/a     | yes      |
+| sso_scim_token                        | AWS SSO SCIM token                                                   | string  | n/a     | yes      |
+| sso_tenant_id                         | AWS SSO tenant ID                                                    | string  | n/a     | yes      |

--- a/auth0-rules/saml-mappings.js
+++ b/auth0-rules/saml-mappings.js
@@ -7,7 +7,6 @@ function (user, context, callback) {
   // AWS requires the SAML nameID format to be an email address, which must
   // exactly match an existing user in AWS SSO:
   // https://docs.aws.amazon.com/singlesignon/latest/userguide/troubleshooting.html
-  const anyAuthorisedEmail = user.emails.find(item => item)
   user.email = user.nickname + allowedDomain
   user.name = user.nickname + allowedDomain
 

--- a/auth0.tf
+++ b/auth0.tf
@@ -88,14 +88,12 @@ resource "auth0_rule" "allow_github_organisations" {
   order   = 10
 }
 
-# NB: This rule is turned off due to people within the organisation not having a
-# verified email address.
-# resource "auth0_rule" "allow_email_addresses" {
-#   name    = "Allow specific email addresses attached to a GitHub user"
-#   script  = file("${path.module}/auth0-rules/allow-email-addresses.js")
-#   enabled = true
-#   order   = 20
-# }
+resource "auth0_rule" "allow_email_addresses" {
+  name    = "Allow specific email addresses attached to a GitHub user"
+  script  = file("${path.module}/auth0-rules/allow-email-addresses.js")
+  enabled = var.auth0_rule_enable_email_address_check
+  order   = 20
+}
 
 resource "auth0_rule" "saml_mappings" {
   name    = "Map user data to the correct SAML attributes"

--- a/auth0.tf
+++ b/auth0.tf
@@ -55,11 +55,6 @@ resource "auth0_connection" "github_saml_connection" {
 
 # Auth0 Rules: Set the configuration variables,
 # which are accessible in Auth0 rules
-resource "auth0_rule_config" "aws_account_id" {
-  key   = "AWS_ACCOUNT_ID"
-  value = data.aws_caller_identity.current.account_id
-}
-
 resource "auth0_rule_config" "github_allowed_organisations" {
   key   = "ALLOWED_ORGANISATIONS"
   value = jsonencode(var.auth0_github_allowed_orgs)
@@ -93,12 +88,14 @@ resource "auth0_rule" "allow_github_organisations" {
   order   = 10
 }
 
-resource "auth0_rule" "allow_email_addresses" {
-  name    = "Allow specific email addresses attached to a GitHub user"
-  script  = file("${path.module}/auth0-rules/allow-email-addresses.js")
-  enabled = true
-  order   = 20
-}
+# NB: This rule is turned off due to people within the organisation not having a
+# verified email address.
+# resource "auth0_rule" "allow_email_addresses" {
+#   name    = "Allow specific email addresses attached to a GitHub user"
+#   script  = file("${path.module}/auth0-rules/allow-email-addresses.js")
+#   enabled = true
+#   order   = 20
+# }
 
 resource "auth0_rule" "saml_mappings" {
   name    = "Map user data to the correct SAML attributes"

--- a/variables.tf
+++ b/variables.tf
@@ -49,6 +49,12 @@ variable "auth0_aws_sso_issuer_url" {
   type        = string
 }
 
+variable "auth0_rule_enable_email_address_check" {
+  type        = bool
+  description = "Whether to enable the email address check rule in Auth0"
+  default     = false
+}
+
 variable "sso_aws_region" {
   type        = string
   description = "Region that AWS SSO is configured in (required for the SCIM URL)"


### PR DESCRIPTION
This turns off the rule for checking email addresses by default. You must still be a member of the GitHub organisation given in `var.auth0_github_allowed_orgs` to authenticate via Auth0 to use AWS SSO, if this rule is not enabled.

Also removes some unused variables.