### PR TITLE
Add correct scopes into the Auth0 GitHub SAML connection

### DIFF
--- a/auth0.tf
+++ b/auth0.tf
@@ -48,8 +48,8 @@ resource "auth0_connection" "github_saml_connection" {
   options {
     client_id     = var.auth0_github_client_id
     client_secret = var.auth0_github_client_secret
-    # Scope definitions aren't supported, but these are the ones you need in Auth0
-    scopes = ["read:user", "read:org", "email"]
+    # These are the minimum scopes you need for a GitHub SAML connection and AWS SSO.
+    scopes = ["read_user", "read_org", "email", "profile"]
   }
 }
 


### PR DESCRIPTION
This PR adds and corrects previous scope definitions, which are now supported in the Auth0 GitHub social connection API.