### PR TITLE
Bump auth0/auth0 to use 0.35.0 or newer

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     auth0 = {
       source  = "auth0/auth0"
-      version = "0.31.0"
+      version = ">=0.35.0"
     }
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
This PR updates `required_providers` to use version 0.35.0 or newer; after 0.35.0 needed a one-time fix to due to a change in how the `options` attribute is created in a Terraform statefile.

The error was as follows:

```sh
│ Error: Failed to decode resource from state
│ 
│ Error decoding "module.sso.auth0_connection.github_saml_connection" from previous state: unsupported attribute "app_domain"
╵
╷
│ Error: string is required
│ 
│   with module.sso.auth0_connection.github_saml_connection,
│   on ${moduleSource} line 47, in resource "auth0_connection" "github_saml_connection":
│   47:   options {
```

The fix for this is removing the auth0_connection from the Terraform state and reimporting it in the [`aws-root-account`](https://github.com/ministryofjustice/aws-root-account) repository:

```
terraform state rm module.sso.auth0_connection.github_saml_connection
terraform import module.sso.auth0_connection.github_saml_connection ${connId}
```