### PR TITLE
Remove unneccessary attribute

### DIFF
--- a/auth0.tf
+++ b/auth0.tf
@@ -43,7 +43,6 @@ resource "auth0_client" "saml" {
 resource "auth0_connection" "github_saml_connection" {
   name            = "GitHub"
   strategy        = "github"
-  enabled_clients = [auth0_client.saml.id]
   options {
     client_id     = var.auth0_github_client_id
     client_secret = var.auth0_github_client_secret

--- a/auth0.tf
+++ b/auth0.tf
@@ -41,8 +41,8 @@ resource "auth0_client" "saml" {
 
 # # Auth0: Connection setup
 resource "auth0_connection" "github_saml_connection" {
-  name            = "GitHub"
-  strategy        = "github"
+  name     = "GitHub"
+  strategy = "github"
   options {
     client_id     = var.auth0_github_client_id
     client_secret = var.auth0_github_client_secret


### PR DESCRIPTION
When updating the provider version the following error occurs:

```
│ Error: Value for unconfigurable attribute
│ 
│   with module.sso.auth0_connection.github_saml_connection,
│   on .terraform/modules/sso/auth0.tf line 46, in resource "auth0_connection" "github_saml_connection":
│   46:   enabled_clients = [auth0_client.saml.id]
│ 
│ Can't configure a value for "enabled_clients": its value will be decided automatically based on the result of applying
│ this configuration.

```

Removing this attribute as no longer needed.  No changes in plan as a result of this. (other than fixing the error)