### PR TITLE
Return attributes to `HTTP`  in line with documentation

### DIFF
--- a/auth0-actions/allow-github-organisations-and-map-saml.js
+++ b/auth0-actions/allow-github-organisations-and-map-saml.js
@@ -46,8 +46,8 @@ exports.onExecutePostLogin = async (event, api) => {
         // AWS requires the SAML nameID format to be an email address, which must
         // exactly match an existing user in AWS SSO:
         // https://docs.aws.amazon.com/singlesignon/latest/userguide/troubleshooting.html
-        api.samlResponse.setAttribute('https://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress', `${event.user.nickname}${allowedDomain}`)
-        api.samlResponse.setAttribute('https://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', `${event.user.nickname}${allowedDomain}`)
+        api.samlResponse.setAttribute('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress', `${event.user.nickname}${allowedDomain}`)
+        api.samlResponse.setAttribute('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', `${event.user.nickname}${allowedDomain}`)
 
         // Set SAML attribute for the user's GitHub team memberships
         const userTeamsResponse = await octokit.request('GET /user/teams').catch(error => api.access.deny(`Error retrieving teams from GitHub: ${error}`))

--- a/auth0-actions/allow-github-organisations-and-map-saml.test.js
+++ b/auth0-actions/allow-github-organisations-and-map-saml.test.js
@@ -59,8 +59,8 @@ describe('onExecutePostLogin', () => {
 
     expect(mockApi.access.deny).not.toHaveBeenCalled()
     expect(mockApi.samlResponse.setAttribute.mock.calls).toEqual([
-      ['https://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress', 'test-user@example.com'],
-      ['https://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', 'test-user@example.com'],
+      ['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress', 'test-user@example.com'],
+      ['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', 'test-user@example.com'],
       ['https://aws.amazon.com/SAML/Attributes/PrincipalTag:github_team', 'test-team-1,test-team-2'],
     ])
   })


### PR DESCRIPTION
As per [the AWS docs](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_saml_assertions.html), this reverts the protocol used for the `emailaddress` and `name` values to the documented use of HTTP.