### PR TITLE
Resolve SAML assertion issues

### DIFF
--- a/auth0-actions/allow-github-organisations-and-map-saml.js
+++ b/auth0-actions/allow-github-organisations-and-map-saml.js
@@ -53,7 +53,7 @@ exports.onExecutePostLogin = async (event, api) => {
         const userTeamsResponse = await octokit.request('GET /user/teams').catch(error => api.access.deny(`Error retrieving teams from GitHub: ${error}`))
         const userTeamSlugs = userTeamsResponse.data.map(team => team.slug)
         console.log("Joined the following teams:" `${userTeamSlugs.join(',')}`)
-        api.samlResponse.setAttribute('https://aws.amazon.com/SAML/Attributes/PrincipalTag:github_team', `${userTeamSlugs.join(',')}`)
+        api.samlResponse.setAttribute('https://aws.amazon.com/SAML/Attributes/AccessControl:github_team', `${userTeamSlugs.join(',')}`)
 
         return // this empty return is required by auth0 to continue to the next action
       }

--- a/auth0-actions/allow-github-organisations-and-map-saml.js
+++ b/auth0-actions/allow-github-organisations-and-map-saml.js
@@ -52,7 +52,8 @@ exports.onExecutePostLogin = async (event, api) => {
         // Set SAML attribute for the user's GitHub team memberships
         const userTeamsResponse = await octokit.request('GET /user/teams').catch(error => api.access.deny(`Error retrieving teams from GitHub: ${error}`))
         const userTeamSlugs = userTeamsResponse.data.map(team => team.slug)
-        api.samlResponse.setAttribute('https://aws.amazon.com/SAML/Attributes/PrincipalTag:github_team', userTeamSlugs.join(','))
+        console.log("Joined the following teams:" `${userTeamSlugs.join(',')}`)
+        api.samlResponse.setAttribute('https://aws.amazon.com/SAML/Attributes/PrincipalTag:github_team', `${userTeamSlugs.join(',')}`)
 
         return // this empty return is required by auth0 to continue to the next action
       }

--- a/auth0-actions/allow-github-organisations-and-map-saml.js
+++ b/auth0-actions/allow-github-organisations-and-map-saml.js
@@ -52,7 +52,6 @@ exports.onExecutePostLogin = async (event, api) => {
         // Set SAML attribute for the user's GitHub team memberships
         const userTeamsResponse = await octokit.request('GET /user/teams').catch(error => api.access.deny(`Error retrieving teams from GitHub: ${error}`))
         const userTeamSlugs = userTeamsResponse.data.map(team => team.slug)
-        console.log("Joined the following teams:" `${userTeamSlugs.join(',')}`)
         api.samlResponse.setAttribute('https://aws.amazon.com/SAML/Attributes/AccessControl:github_team', `${userTeamSlugs.join(',')}`)
 
         return // this empty return is required by auth0 to continue to the next action

--- a/auth0-actions/allow-github-organisations-and-map-saml.test.js
+++ b/auth0-actions/allow-github-organisations-and-map-saml.test.js
@@ -61,7 +61,7 @@ describe('onExecutePostLogin', () => {
     expect(mockApi.samlResponse.setAttribute.mock.calls).toEqual([
       ['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress', 'test-user@example.com'],
       ['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', 'test-user@example.com'],
-      ['https://aws.amazon.com/SAML/Attributes/PrincipalTag:github_team', 'test-team-1,test-team-2'],
+      ['https://aws.amazon.com/SAML/Attributes/AccessControl:github_team', 'test-team-1,test-team-2'],
     ])
   })
 


### PR DESCRIPTION
This PR makes a few changes to how github teams are passed back as a SAML attribute to AWS.

* Updates the SAML value from `PrincipalTag` to `AccessControl` in line with [this guidance](https://docs.aws.amazon.com/singlesignon/latest/userguide/attributesforaccesscontrol.html).
* Enforces implicit type conversion of the value provided for the SAML assertion to JSON as without this, the payload will be treated as malformed.