### PR TITLE
Align SAML assertion with api docs

### DIFF
--- a/auth0-actions/allow-github-organisations-and-map-saml.js
+++ b/auth0-actions/allow-github-organisations-and-map-saml.js
@@ -53,8 +53,9 @@ exports.onExecutePostLogin = async (event, api) => {
         // Ensure character limit stays inside documented constraint
         const userTeamsResponse = await octokit.request('GET /user/teams').catch(error => api.access.deny(`Error retrieving teams from GitHub: ${error}`))
         const userTeamSlugs     = userTeamsResponse.data.map(team => team.slug)
-        const limitTeamSlugs    = userTeamSlugs.join(':').substring(0, 255)
-        api.samlResponse.setAttribute('https://aws.amazon.com/SAML/Attributes/AccessControl:github_team', `${limitTeamSlugs}`)
+        const joinTeamSlugs     = userTeamSlugs.join(':')
+        const trimTeamSlugs     = joinTeamSlugs.slice(0, 256)
+        api.samlResponse.setAttribute('https://aws.amazon.com/SAML/Attributes/AccessControl:github_team', `${trimTeamSlugs}`)
 
         return // this empty return is required by auth0 to continue to the next action
       }

--- a/auth0-actions/allow-github-organisations-and-map-saml.js
+++ b/auth0-actions/allow-github-organisations-and-map-saml.js
@@ -52,7 +52,7 @@ exports.onExecutePostLogin = async (event, api) => {
         // Set SAML attribute for the user's GitHub team memberships
         const userTeamsResponse = await octokit.request('GET /user/teams').catch(error => api.access.deny(`Error retrieving teams from GitHub: ${error}`))
         const userTeamSlugs = userTeamsResponse.data.map(team => team.slug)
-        api.samlResponse.setAttribute('https://aws.amazon.com/SAML/Attributes/AccessControl:github_team', `${userTeamSlugs.join(',')}`)
+        api.samlResponse.setAttribute('https://aws.amazon.com/SAML/Attributes/AccessControl:github_team', `${userTeamSlugs.join(':')}`)
 
         return // this empty return is required by auth0 to continue to the next action
       }

--- a/auth0-actions/allow-github-organisations-and-map-saml.js
+++ b/auth0-actions/allow-github-organisations-and-map-saml.js
@@ -53,7 +53,7 @@ exports.onExecutePostLogin = async (event, api) => {
         // Ensure character limit stays inside documented constraint
         const userTeamsResponse = await octokit.request('GET /user/teams').catch(error => api.access.deny(`Error retrieving teams from GitHub: ${error}`))
         const userTeamSlugs     = userTeamsResponse.data.map(team => team.slug)
-        const limitTeamSlugs    = userTeamSlugs.join(':').substring(0, 256)
+        const limitTeamSlugs    = userTeamSlugs.join(':').substring(0, 255)
         api.samlResponse.setAttribute('https://aws.amazon.com/SAML/Attributes/AccessControl:github_team', `${limitTeamSlugs}`)
 
         return // this empty return is required by auth0 to continue to the next action

--- a/auth0-actions/allow-github-organisations-and-map-saml.test.js
+++ b/auth0-actions/allow-github-organisations-and-map-saml.test.js
@@ -61,7 +61,7 @@ describe('onExecutePostLogin', () => {
     expect(mockApi.samlResponse.setAttribute.mock.calls).toEqual([
       ['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress', 'test-user@example.com'],
       ['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', 'test-user@example.com'],
-      ['https://aws.amazon.com/SAML/Attributes/AccessControl:github_team', 'test-team-1,test-team-2'],
+      ['https://aws.amazon.com/SAML/Attributes/AccessControl:github_team', 'test-team-1:test-team-2'],
     ])
   })
 


### PR DESCRIPTION
Aligns separator used in `join()` with [AWS STS API](https://docs.aws.amazon.com/STS/latest/APIReference/API_Tag.html) docs on tagging.
Without this, the combined string of user teams will fail the AWS-side tests for regular expressions.
Also applies `slice()` to ensure the value length for the assertion stays inside the documented character limit for tag values.