### PR TITLE
Revert "Revert "New Azure connection for entraid""

### DIFF
--- a/auth0.tf
+++ b/auth0.tf
@@ -74,6 +74,31 @@ resource "auth0_connection" "github_saml_connection" {
   }
 }
 
+resource "auth0_connection" "azure_entraid_connection" {
+  display_name   = "Azure EntraID PoC - Do not use"
+  name           = "azure-entraid"
+  strategy       = "waad"
+  show_as_button = true
+  options {
+    identity_api  = "microsoft-identity-platform-v2.0"
+    client_id     = var.auth0_azure_entraid_client_id
+    client_secret = var.auth0_azure_entraid_client_secret
+    app_id        = auth0_client.saml.id
+    domain        = var.auth0_azure_entraid_domain
+
+    waad_protocol          = "openid-connect"
+    max_groups_to_retrieve = 50
+    api_enable_users       = false
+    scopes = [
+      "basic_profile",
+      "ext_groups",
+
+    ]
+    set_user_root_attributes               = "on_each_login"
+    should_trust_email_verified_connection = "always_set_emails_as_verified"
+  }
+}
+
 # Auth0 actions
 resource "auth0_action" "allow_github_organisations" {
   name    = "Allow specific GitHub Organisations and map SAML attributes"

--- a/variables.tf
+++ b/variables.tf
@@ -54,3 +54,22 @@ variable "auth0_aws_sso_issuer_url" {
   type        = string
   sensitive   = true
 }
+
+variable "auth0_azure_entraid_client_id" {
+  description = "Client id for the azures application"
+  type        = string
+  sensitive   = true
+}
+
+variable "auth0_azure_entraid_client_secret" {
+  description = "Client secret for the azures application"
+  type        = string
+  sensitive   = true
+}
+
+variable "auth0_azure_entraid_domain" {
+  description = "Azures application domain name"
+  type        = string
+  sensitive   = true
+
+}


### PR DESCRIPTION
Reverts ministryofjustice/moj-terraform-aws-sso#53

Issue with the previous release has been resolved, we can now release this :) 

This PR covers work for the following issue Integration of EntraID Identity into AWS SSO
https://github.com/ministryofjustice/modernisation-platform/issues/6227

which is to create a new connection for the justice domain on azures for allowing the data platform team and future users to be able to access the mod platform.