### PR TITLE
🔧 Fix Action Not Skipping Azure Connections

### DIFF
--- a/auth0-actions/allow-github-organisations-and-map-saml.js
+++ b/auth0-actions/allow-github-organisations-and-map-saml.js
@@ -8,7 +8,7 @@
 const { Octokit } = require('@octokit/rest')
 const { ManagementClient } = require('auth0')
 
-async function getIdpAccessToken (clientId, clientSecret, tenantDomain, userId) {
+async function getIdpAccessToken(clientId, clientSecret, tenantDomain, userId) {
   const management = new ManagementClient({
     domain: tenantDomain,
     clientId,
@@ -16,7 +16,7 @@ async function getIdpAccessToken (clientId, clientSecret, tenantDomain, userId) 
   })
 
   const response = await management.users.get({ id: userId })
-  return response.data.identities.find(function (identity) {
+  return response.data.identities.find(function(identity) {
     return identity.provider.toLowerCase() === 'github'
   })
 }
@@ -24,8 +24,8 @@ async function getIdpAccessToken (clientId, clientSecret, tenantDomain, userId) 
 exports.onExecutePostLogin = async (event, api) => {
   const { AUTH0_MANAGEMENT_CLIENT_ID, AUTH0_MANAGEMENT_CLIENT_SECRET, AUTH0_TENANT_DOMAIN, ALLOWED_ORGANISATIONS } = event.secrets
   const allowedOrganisations = JSON.parse(ALLOWED_ORGANISATIONS)
-  if (event.connection.strategy.toLowerCase() === 'azure-entraid') {
-    return;
+  if (event.connection.name.toLowerCase() === 'azure-entraid') {
+    return
   }
   if (event.connection.strategy.toLowerCase() === 'github') {
     const identity = event.user.identities.find(identity => identity.provider.toLowerCase() === 'github')
@@ -54,9 +54,9 @@ exports.onExecutePostLogin = async (event, api) => {
         // Set SAML attribute for the user's GitHub team memberships
         // Ensure character limit stays inside documented constraint
         const userTeamsResponse = await octokit.request('GET /user/teams').catch(error => api.access.deny(`Error retrieving teams from GitHub: ${error}`))
-        const userTeamSlugs     = userTeamsResponse.data.map(team => team.slug)
-        const joinTeamSlugs     = userTeamSlugs.join(':')
-        const trimTeamSlugs     = joinTeamSlugs.slice(0, 256)
+        const userTeamSlugs = userTeamsResponse.data.map(team => team.slug)
+        const joinTeamSlugs = userTeamSlugs.join(':')
+        const trimTeamSlugs = joinTeamSlugs.slice(0, 256)
         api.samlResponse.setAttribute('https://aws.amazon.com/SAML/Attributes/AccessControl:github_team', `${trimTeamSlugs}`)
 
         return // this empty return is required by auth0 to continue to the next action

--- a/auth0-actions/allow-github-organisations-and-map-saml.test.js
+++ b/auth0-actions/allow-github-organisations-and-map-saml.test.js
@@ -41,7 +41,7 @@ describe('onExecutePostLogin', () => {
         ALLOWED_ORGANISATIONS: '["ministryofjustice"]',
         ALLOWED_DOMAINS: '["@example.com"]',
       },
-      connection: { strategy: 'github' },
+      connection: { strategy: 'github', name: '' },
       user: { identities: [{ provider: 'github' }], nickname: 'test-user' },
     }
     mockApi = {
@@ -74,10 +74,10 @@ describe('onExecutePostLogin', () => {
     expect(mockApi.samlResponse.setAttribute).not.toHaveBeenCalled()
   })
 
-  test('access denied given event connection strategy is not `github`', async () => {
+  test('access denied given event connection strategy is not `github` or connection name is not `azure-entraid', async () => {
     mockEvent = {
       ...mockEvent,
-      connection: { strategy: 'NOT_GITHUB' },
+      connection: { strategy: 'NOT_GITHUB', name: 'NOT_ENTRA' },
     }
 
     await onExecutePostLogin(mockEvent, mockApi)


### PR DESCRIPTION
## 👀 Purpose

- Fixes #61 
- To skip azure connections because the action is used for GitHub connections to map GitHub Teams

## ♻️ What's changed

- Using the `name` property instead of the `strategy`
- Updated unit tests to accommodate the structure required for Azure connections

## 📝 Notes

- As per the [Auth0 Docs](https://auth0.com/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-event-object) - Enterprise connections have different properties. Using the name here will ensure we capture when someone is authenticating with our azure-entraid connection 