### PR TITLE
✨ Add MP as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ministryofjustice/aws-root-account-admin-team
+* @ministryofjustice/aws-root-account-admin-team @ministryofjustice/modernisation-platform


### PR DESCRIPTION
## 👀 Purpose

- To allow MP to approve PRs, manage dependabot alerts and maintain the repository more autonomously

## ♻️ What's changed

- Added the modernisation-platform team as CODEOWNERS